### PR TITLE
fixing space to match design and annotated file

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -2,6 +2,7 @@
 
 body {
     font-family: 'Source Sans Pro', sans-serif;
+    color: #2b2b2b;
 }
 
 #about, #work, #contact {
@@ -32,12 +33,12 @@ body {
 #about h2 {
     font-family: 'Lora', serif;
     font-size: 36px;
+    padding-left: 50px;
 }
 #about p {
     font-size: 21px;
     color: #7f7f7f;
-    line-height: 42px;
+    line-height: 40px;
+    padding-left: 50px;
     padding-right: 50px;
 }
-
-


### PR DESCRIPTION
We are missing some padding and have some line-heights that differ from our annotated jpegs, lesson notes, and the design. This makes those adjustments.