### PR TITLE
fixing space to match design and annotated file

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -2,6 +2,7 @@
 
 body {
     font-family: 'Source Sans Pro', sans-serif;
+    color: #2b2b2b;
 }
 
 #about, #work, #contact {
@@ -22,4 +23,3 @@ body {
     width: 400px;
     float: left;
 }
-


### PR DESCRIPTION
We are missing some padding and have some line-heights that differ from our annotated jpegs, lesson notes, and the design. This makes those adjustments.